### PR TITLE
Update CommonAwsPolicies.ps1

### DIFF
--- a/DataConnectors/AWS-S3/Utils/CommonAwsPolicies.ps1
+++ b/DataConnectors/AWS-S3/Utils/CommonAwsPolicies.ps1
@@ -66,7 +66,7 @@ function Get-OIDCRoleArnPolicy {
 				'Condition' = @{
 					'StringEquals' = @{
 						"sts.windows.net/$($SentinelTenantId)/:aud" = "$($SentinelClientId)";
-						'sts:RoleSessionName'                       = "MicrosoftSentinel_$($WorkspaceId)";
+						'sts:RoleSessionName'                       = "MicrosoftDefenderForClouds_$($WorkspaceId)";
 					};
 				};
 			}


### PR DESCRIPTION
The RoleSessionName that Microsoft sends has changed from MicrosoftSentinel_ to MicrosoftDefenderForClouds_

  
   Change(s):
   - The RoleSessionName that Microsoft sends has changed from MicrosoftSentinel_ to MicrosoftDefenderForClouds_

   Reason for Change(s):
   - Failed to connect to AWS s3 from sentinel 
     Data fetch failed (Failed to fetch authentication token for arn:aws:iam::<aws account>:role/<rolename>. Please make sure that the OpenIDConnect provider and Assume role trust relationship are configured correctly to allow sts: AssumeRoleWithWebIdentity operation)

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


